### PR TITLE
ci: remove duplicate bootstrap cross-platform check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,26 +122,3 @@ jobs:
         with:
           files: ./cobertura.xml
           fail_ci_if_error: false
-
-  bootstrap-cross-platform:
-    name: Bootstrap Cross-Platform Check
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Install protoc (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - name: Install protoc (macOS)
-        if: runner.os == 'macOS'
-        run: brew install protobuf
-      - name: Install protoc (Windows)
-        if: runner.os == 'Windows'
-        run: choco install protoc -y
-      # 只编译不跑测试：引导器运行时逻辑是 Linux 专属（K3s/buildah），
-      # 本矩阵证明它在三平台都能通过编译（cfg 门控无遗漏）
-      - run: cargo check -p cogneva-bootstrap


### PR DESCRIPTION
## Summary
- Remove the duplicate bootstrap cross-platform CI matrix.
- Retain the existing three-platform bootstrap compile check.

## Validation
- git diff --check