### PR TITLE
修复 Agent 析构阶段重复创建 Tokio Runtime

### DIFF
--- a/crates/cog-agent/src/agent.rs
+++ b/crates/cog-agent/src/agent.rs
@@ -1018,7 +1018,7 @@ impl Drop for Agent {
     fn drop(&mut self) {
         // Abort consumer and heartbeat tasks if present.
         if let Ok(inner) = self.inner.try_lock() {
-            if let Some(ref handle) = inner.consumer_handle {
+            if let Some(ref handle) = inner.task_handle {
                 handle.abort();
             }
             if let Some(ref handle) = inner.consumer_handle {
@@ -1032,16 +1032,9 @@ impl Drop for Agent {
         if let Some(ref lifecycle) = self.lifecycle {
             let agent_id = self.config.agent_id.clone();
             let lifecycle = lifecycle.clone();
-            // Best-effort async cleanup: spawn a blocking task to stop heartbeat.
-            // In a tokio runtime this will run; outside it silently does nothing.
-            let _ = std::thread::spawn(move || {
-                let rt = tokio::runtime::Runtime::new();
-                if let Ok(rt) = rt {
-                    rt.block_on(async move {
-                        lifecycle.stop_heartbeat(&agent_id).await;
-                        let _ = lifecycle.transition(&agent_id, AgentState::Inactive).await;
-                    });
-                }
+            schedule_cleanup(async move {
+                lifecycle.stop_heartbeat(&agent_id).await;
+                let _ = lifecycle.transition(&agent_id, AgentState::Inactive).await;
             });
         }
 
@@ -1049,14 +1042,27 @@ impl Drop for Agent {
         if let Some(ref registry) = self.registry {
             let agent_id = self.config.agent_id.clone();
             let registry = registry.clone();
-            let _ = std::thread::spawn(move || {
-                let rt = tokio::runtime::Runtime::new();
-                if let Ok(rt) = rt {
-                    rt.block_on(async move {
-                        let _ = registry.deregister(&agent_id).await;
-                    });
-                }
+            schedule_cleanup(async move {
+                let _ = registry.deregister(&agent_id).await;
             });
+        }
+    }
+}
+
+/// Run best-effort cleanup on the runtime that owns the agent.
+///
+/// `Drop` must not create a runtime or wait for I/O: either can deadlock during
+/// shutdown. If the agent is dropped outside Tokio, there is no runtime left to
+/// safely drive asynchronous cleanup, so the work is skipped.
+fn schedule_cleanup(task: impl std::future::Future<Output = ()> + Send + 'static) -> bool {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => {
+            handle.spawn(task);
+            true
+        }
+        Err(_) => {
+            tracing::debug!("skipping agent cleanup outside a Tokio runtime");
+            false
         }
     }
 }
@@ -1143,5 +1149,38 @@ async fn run_agent_task(
                 let _ = result_tx.send(snap);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::schedule_cleanup;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    #[tokio::test]
+    async fn cleanup_task_uses_the_current_runtime() {
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran_by_task = ran.clone();
+
+        assert!(schedule_cleanup(async move {
+            ran_by_task.store(true, Ordering::SeqCst);
+        }));
+
+        tokio::task::yield_now().await;
+        assert!(ran.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn cleanup_task_is_skipped_without_a_runtime() {
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran_by_task = ran.clone();
+
+        assert!(!schedule_cleanup(async move {
+            ran_by_task.store(true, Ordering::SeqCst);
+        }));
+        assert!(!ran.load(Ordering::SeqCst));
     }
 }


### PR DESCRIPTION
## 改动说明
- Agent 析构时复用当前 Tokio 运行时提交心跳停用、状态迁移和注册注销任务。
- 删除析构过程中创建线程与 Runtime 的逻辑，避免关闭阶段等待异步 I/O。
- 修正主任务句柄未中止、consumer 句柄重复中止的问题。
- 新增运行时内投递与无运行时跳过清理的单元测试。

## 验证
- cargo fmt --all -- --check
- git diff --check
- cargo test -p cog-agent cleanup_task：未能启动，当前环境缺少未缓存的 workspace 依赖 aws-sdk-s3。

关联 #5