### PR TITLE
docs: add Windows environment requirements and quick-start steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,12 +548,30 @@ The **same command**. K3s needs a Linux kernel, so the script automatically inst
 
 ### 🪟 Windows
 
+Windows gets the **same one-liner experience**, with one extra layer behind the scenes: K3s cannot natively run on Windows, so `bootstrap.ps1` prepares WSL2 + Ubuntu as the Linux layer, then executes the exact same Linux one-liner inside it.
+
+**Environment requirements** — everything not listed here is auto-installed by the bootstrapper:
+
+- **Windows 10 2004+ (build 19041+) or Windows 11**, with virtualization (VT-x/AMD-V) enabled in BIOS/UEFI — WSL2 needs it;
+- **PowerShell running as Administrator** — Windows PowerShell 5.1 (built-in) or PowerShell 7+, launched via *Run as administrator*;
+- **Network access** to GitHub (restricted networks are handled automatically by switching to China mirrors);
+- **No manual WSL, Rust toolchain, Docker, or cluster setup**: the bootstrapper installs WSL2 + Ubuntu when missing and provisions/repairs every dependency (Rust, container runtime, K3s/buildah, …) inside WSL — zero host footprint.
+
+**Quick start**:
+
 ```powershell
 # Administrator PowerShell
 iwr -useb https://raw.githubusercontent.com/hcipengm/cogneva/main/bootstrap.ps1 | iex
 ```
 
-The script installs WSL2 + Ubuntu (prompts for a reboot if required — just re-run it afterwards, it is idempotent), then runs the same one-liner inside WSL. WSL2's default localhostForwarding exposes the WebUI at <http://localhost:8080>. Force China mirrors with `-CnMirror 1`: download the script first and pipe it, e.g. `& ([scriptblock]::Create((iwr -useb <url>).Content)) -CnMirror 1`.
+1. Open **Start**, type *PowerShell* (or *Terminal*), right-click it and choose **Run as administrator**;
+2. Paste the command above and press Enter — the script installs WSL2 + Ubuntu if needed, then hands over to the same unattended meta-bootstrap as Linux;
+3. If Windows asks for a **reboot** (WSL components need it), restart and re-run the *same* command afterwards — the script is idempotent and continues from where it stopped;
+4. Wait for the in-WSL bootstrap to finish: the first run downloads Ubuntu and all dependencies, so the time depends on your network;
+5. Done — WSL2's default localhostForwarding exposes the WebUI at <http://localhost:8080>; complete the mandatory LLM setup wizard on first visit;
+6. Day-to-day management: `wsl -d Ubuntu` to enter the Linux layer, `wsl --shutdown` to stop the VM.
+
+Force China mirrors with `-CnMirror 1`: download the script first and pipe it with the parameter, e.g. `& ([scriptblock]::Create((iwr -useb <url>).Content)) -CnMirror 1`.
 
 > The first URL is GitHub's official raw endpoint; if it is unreachable (e.g. restricted networks), the command automatically falls back to the Gitee mirror. The bootstrap script itself also falls back to the Gitee repo when fetching source code.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -544,12 +544,30 @@ Cogneva 支持**元启动（Meta-bootstrap）**：从一台空白机器（Linux 
 
 ### 🪟 Windows
 
+Windows 与 Linux/macOS 是**同一条一键命令**，只是背后多一层：K3s 不能原生运行于 Windows，`bootstrap.ps1` 会先准备 WSL2 + Ubuntu 作为 Linux 运行层，再在 WSL 内执行与 Linux 完全相同的引导命令。
+
+**环境要求**（除下列外，其余全部由引导器自动安装）：
+
+- **Windows 10 2004+（内部版本 19041+）或 Windows 11**，且 BIOS/UEFI 已开启虚拟化（VT-x/AMD-V，WSL2 必需）；
+- **管理员权限的 PowerShell**：Windows PowerShell 5.1（系统自带）或 PowerShell 7+，右键"以管理员身份运行"即可；
+- **可访问 GitHub 的网络**（受限网络会自动切换国内镜像，见下）；
+- **无需预装任何东西**：不必手动安装 WSL、Rust 工具链、Docker 或集群——引导器会在 WSL 内自动安装并自修复全部依赖（含 Rust、容器运行时、K3s/buildah 等），宿主零侵入。
+
+**快速开始**：
+
 ```powershell
 # 管理员 PowerShell
 iwr -useb https://raw.githubusercontent.com/hcipengm/cogneva/main/bootstrap.ps1 | iex
 ```
 
-脚本自动安装 WSL2 + Ubuntu（如需重启会提示，重启后重跑本脚本即可，幂等），然后在 WSL 内执行同一条一键命令。WSL2 默认开启 localhostForwarding，WebUI 直接在浏览器访问 <http://localhost:8080>。强制国内镜像：先下载脚本再传参，如 `& ([scriptblock]::Create((iwr -useb <地址>).Content)) -CnMirror 1`。
+1. 开始菜单搜索 **PowerShell**（或"终端"），右键选择**以管理员身份运行**；
+2. 粘贴上面这条命令并回车——脚本发现缺 WSL2 + Ubuntu 会自动安装，随后在 WSL 内进入与 Linux 相同的全自动元启动；
+3. 若 Windows 提示需要**重启**（安装 WSL 组件后通常需要），重启后再次运行**同一条命令**即可——脚本幂等，会从断点继续；
+4. 等待 WSL 内引导完成：首次运行需下载 Ubuntu 与全部依赖，耗时取决于网速；
+5. 完成。WSL2 默认开启 localhostForwarding，WebUI 直接在浏览器访问 <http://localhost:8080>，按首次弹出的 LLM 配置向导完成接入；
+6. 日常管理：`wsl -d Ubuntu` 进入 Linux 层，`wsl --shutdown` 停止运行。
+
+强制国内镜像：先下载脚本再传参，如 `& ([scriptblock]::Create((iwr -useb <地址>).Content)) -CnMirror 1`。
 
 > 第一个地址是 GitHub 官方 raw 地址；如果访问不通（比如国内受限网络），命令会自动切换到 Gitee 镜像下载，无需手动选择。脚本内部拉取源码时同样会自动回退到 Gitee 仓库。
 


### PR DESCRIPTION
针对 #4：README 此前虽有简短的 Windows 一键命令段落，但缺少 issue 点名的「环境要求」与结构化快速开始步骤，Windows 用户难以直接上手。

本次改动将 README.md 与 README.zh-CN.md 的 Windows 小节同步扩充为：
- **环境要求**：Windows 10 2004+ (build 19041+) / Windows 11、BIOS/UEFI 开启虚拟化（WSL2 前提）、管理员权限 PowerShell（Windows PowerShell 5.1 或 PowerShell 7+）、网络说明；并明确宿主**无需**预装 WSL / Rust 工具链 / Docker / 集群——全部由 bootstrap.ps1 在 WSL Ubuntu 内自动安装并自修复（与 macOS/Lima 段"宿主零侵入"的口径一致）。
- **快速开始分步**：管理员 PowerShell → 粘贴一键命令 → 如需重启则重跑（幂等，从断点继续）→ 等待 WSL 内引导完成 → WebUI 访问 http://localhost:8080 → 日常管理（wsl -d Ubuntu / wsl --shutdown）。

所有表述均以 bootstrap.ps1 实际行为为准：#Requires -RunAsAdministrator、wsl --install -d Ubuntu、exit 3010 重启分支、WSL 内执行与 Linux 完全相同的 bootstrap.sh 一行命令、WSL2 localhostForwarding 暴露 WebUI。

Closes #4