### PR TITLE
fix(auth): fail fast on weak/default JWT HMAC secrets

### DIFF
--- a/cogneva.example.json
+++ b/cogneva.example.json
@@ -229,6 +229,7 @@
     "archive_poll_interval_secs": 300
   },
   "gateway": {
+    "_comment": "JWT 签名密钥不在配置文件中明文存放：运行时从环境变量 COGNEVA_JWT_SECRET 读取（由安装器生成并注入集群 Secret，见 deploy/helm/cogneva/templates/secret.yaml 与 deploy/scripts/init-secrets.sh）。要求长度 ≥32 字节且不得使用公开占位符 'change-me-in-production'，否则启动被拒绝（fail-fast，见 crates/cog-auth/src/jwt.rs）；未设置时回退为每次启动随机生成的临时密钥（重启后所有 token 失效）。access_token_ttl_minutes=0 表示用内置默认值。",
     "http_port": 8080,
     "ws_port": 8081,
     "metrics_port": 9090,

--- a/crates/cog-auth/src/jwt.rs
+++ b/crates/cog-auth/src/jwt.rs
@@ -5,6 +5,14 @@ use uuid::Uuid;
 use crate::error::{AuthError, AuthResult};
 use cog_core::{Claims, Permission, Role, User, UserType};
 
+/// Well-known placeholder signing secret from pre-hardening defaults. Refused
+/// at startup outside explicitly-opted-in demo mode: HS256 with a public
+/// secret lets anyone forge an admin token offline.
+pub const KNOWN_WEAK_SECRET: &str = "change-me-in-production";
+
+/// Minimum acceptable length (bytes) for an HMAC signing secret.
+pub const MIN_HMAC_SECRET_LEN: usize = 32;
+
 /// JWT configuration.
 #[derive(Debug, Clone)]
 pub struct JwtConfig {
@@ -17,18 +25,23 @@ pub struct JwtConfig {
     pub private_key_pem: Option<String>,
     /// RSA public key in PEM format (for RS256 verification).
     pub public_key_pem: Option<String>,
+    /// Explicitly allow the well-known placeholder / short HMAC secret.
+    /// Must stay `false` outside throwaway demo deployments: with `true`,
+    /// [`JwtManager::new`] skips the weak-secret rejection.
+    pub allow_weak_secret: bool,
 }
 
 impl Default for JwtConfig {
     fn default() -> Self {
         Self {
-            secret: "change-me-in-production".into(),
+            secret: KNOWN_WEAK_SECRET.into(),
             issuer: "cogneva".into(),
             audience: "cogneva-api".into(),
             access_token_ttl_minutes: 15,
             refresh_token_ttl_days: 7,
             private_key_pem: None,
             public_key_pem: None,
+            allow_weak_secret: false,
         }
     }
 }
@@ -52,6 +65,19 @@ impl JwtManager {
                 DecodingKey::from_rsa_pem(public.as_bytes()).expect("invalid RSA public key PEM");
             (enc, dec, Algorithm::RS256)
         } else {
+            if !config.allow_weak_secret
+                && (config.secret.len() < MIN_HMAC_SECRET_LEN
+                    || config.secret == KNOWN_WEAK_SECRET)
+            {
+                panic!(
+                    "refusing to start JwtManager with an insecure HMAC secret \
+                     ({} byte(s); min {MIN_HMAC_SECRET_LEN}, and must not equal the public \
+                     placeholder '{KNOWN_WEAK_SECRET}'); set COGNEVA_JWT_SECRET to a random \
+                     value of at least {MIN_HMAC_SECRET_LEN} bytes (installers generate one) \
+                     or opt into demo mode with allow_weak_secret",
+                    config.secret.len()
+                );
+            }
             let enc = EncodingKey::from_secret(config.secret.as_bytes());
             let dec = DecodingKey::from_secret(config.secret.as_bytes());
             (enc, dec, Algorithm::HS256)
@@ -226,6 +252,17 @@ pub fn generate_test_rsa_keypair() -> (String, String) {
 mod tests {
     use super::*;
 
+    /// Strong-enough HMAC secret for unit tests (>= [`MIN_HMAC_SECRET_LEN`]
+    /// bytes and distinct from [`KNOWN_WEAK_SECRET`]).
+    const TEST_HMAC_SECRET: &str = "test-hmac-secret-0123456789abcdef0123456789abcdef";
+
+    fn test_config() -> JwtConfig {
+        JwtConfig {
+            secret: TEST_HMAC_SECRET.into(),
+            ..Default::default()
+        }
+    }
+
     fn test_user() -> User {
         User {
             id: Uuid::new_v4(),
@@ -243,7 +280,7 @@ mod tests {
 
     #[test]
     fn generate_and_verify_token() {
-        let mgr = JwtManager::new(JwtConfig::default());
+        let mgr = JwtManager::new(test_config());
         let user = test_user();
         let (access, refresh) = mgr
             .generate_token(&user, vec!["ws-001".into()], vec![Permission::AgentRead])
@@ -260,7 +297,7 @@ mod tests {
 
     #[test]
     fn refresh_access_token_ok() {
-        let mgr = JwtManager::new(JwtConfig::default());
+        let mgr = JwtManager::new(test_config());
         let user = test_user();
         let (access, refresh) = mgr.generate_token(&user, vec![], vec![]).unwrap();
 
@@ -274,10 +311,8 @@ mod tests {
 
     #[test]
     fn expired_token_fails() {
-        let config = JwtConfig {
-            access_token_ttl_minutes: -5,
-            ..Default::default()
-        };
+        let mut config = test_config();
+        config.access_token_ttl_minutes = -5;
         let mgr = JwtManager::new(config);
         let user = test_user();
         let (access, _) = mgr.generate_token(&user, vec![], vec![]).unwrap();
@@ -346,5 +381,35 @@ mod tests {
 
         let err = mgr.verify_token(&access).unwrap_err();
         assert!(matches!(err, AuthError::InvalidToken(_)));
+    }
+
+    #[test]
+    #[should_panic(expected = "insecure HMAC secret")]
+    fn known_weak_secret_is_rejected() {
+        // `JwtConfig::default()` still carries the public placeholder; the
+        // manager must refuse to boot on it unless explicitly opted in.
+        let _ = JwtManager::new(JwtConfig::default());
+    }
+
+    #[test]
+    #[should_panic(expected = "insecure HMAC secret")]
+    fn short_secret_is_rejected() {
+        let config = JwtConfig {
+            secret: "too-short".into(),
+            ..Default::default()
+        };
+        let _ = JwtManager::new(config);
+    }
+
+    #[test]
+    fn weak_secret_allowed_when_explicitly_opted_in() {
+        let config = JwtConfig {
+            allow_weak_secret: true,
+            ..Default::default()
+        };
+        let mgr = JwtManager::new(config);
+        let user = test_user();
+        let (access, _) = mgr.generate_token(&user, vec![], vec![]).unwrap();
+        assert!(!access.is_empty());
     }
 }

--- a/crates/cog-auth/src/plugin.rs
+++ b/crates/cog-auth/src/plugin.rs
@@ -3,11 +3,6 @@
 use std::sync::Arc;
 use tracing::{info, warn};
 
-/// Well-known placeholder from `JwtConfig::default()`. Refused at startup
-/// outside demo mode: HS256 with a public secret means anyone can forge an
-/// admin token offline.
-const KNOWN_WEAK_SECRET: &str = "change-me-in-production";
-
 /// Auth plugin that self-assembles and publishes JWT manager and session manager.
 pub struct AuthPlugin {
     initialized: bool,
@@ -81,8 +76,9 @@ impl cog_core::SystemPlugin for AuthPlugin {
 /// the `COGNEVA_JWT_SECRET` env (injected from the install-time generated
 /// cluster Secret). Unset env falls back to a per-boot random secret with a
 /// loud warning — safe against forgery, but every token dies on restart, so
-/// real deployments must inject the Secret. The known placeholder is refused
-/// unless demo login is explicitly enabled.
+/// real deployments must inject the Secret. Short secrets and the known
+/// placeholder are refused unless demo login is explicitly enabled; the same
+/// rule is enforced again inside `JwtManager::new` as a last line of defense.
 fn resolve_jwt_config(config: &cog_core::Config) -> cog_core::SFResult<crate::jwt::JwtConfig> {
     let mut cfg = crate::jwt::JwtConfig {
         access_token_ttl_minutes: config.gateway.effective_access_token_ttl_minutes() as i64,
@@ -90,13 +86,23 @@ fn resolve_jwt_config(config: &cog_core::Config) -> cog_core::SFResult<crate::jw
     };
     match std::env::var("COGNEVA_JWT_SECRET") {
         Ok(secret) if !secret.is_empty() => {
-            if secret == KNOWN_WEAK_SECRET && !config.gateway.demo_login_enabled {
+            // Throwaway demo deployments (gateway.demo_login_enabled) grant an
+            // admin token to any credentials, so the secret is meaningless
+            // there; allow the weak secret only in that explicit case.
+            let demo = config.gateway.demo_login_enabled;
+            if !demo
+                && (secret.len() < crate::jwt::MIN_HMAC_SECRET_LEN
+                    || secret == crate::jwt::KNOWN_WEAK_SECRET)
+            {
                 return Err(cog_core::SFError::Config(format!(
-                    "COGNEVA_JWT_SECRET is the known placeholder '{KNOWN_WEAK_SECRET}'; \
-                     set a random secret (the installer generates one) or enable \
-                     gateway.demo_login_enabled for throwaway demos"
+                    "COGNEVA_JWT_SECRET must be a random value of at least {} bytes and must \
+                     not be the public placeholder '{}'; set a random secret (the installer \
+                     generates one) or enable gateway.demo_login_enabled for throwaway demos",
+                    crate::jwt::MIN_HMAC_SECRET_LEN,
+                    crate::jwt::KNOWN_WEAK_SECRET
                 )));
             }
+            cfg.allow_weak_secret = demo;
             cfg.secret = secret;
         }
         _ => {

--- a/crates/cog-auth/tests/auth_test.rs
+++ b/crates/cog-auth/tests/auth_test.rs
@@ -11,6 +11,17 @@ use uuid::Uuid;
 // JWT tests
 // ---------------------------------------------------------------------------
 
+/// Strong-enough HMAC secret for integration tests (>= 32 bytes, distinct
+/// from the public placeholder `JwtConfig::default()` carries).
+const TEST_HMAC_SECRET: &str = "test-hmac-secret-0123456789abcdef0123456789abcdef";
+
+fn test_jwt_config() -> JwtConfig {
+    JwtConfig {
+        secret: TEST_HMAC_SECRET.into(),
+        ..Default::default()
+    }
+}
+
 fn test_user() -> User {
     User {
         id: Uuid::new_v4(),
@@ -28,7 +39,7 @@ fn test_user() -> User {
 
 #[test]
 fn jwt_generate_and_verify() {
-    let mgr = JwtManager::new(JwtConfig::default());
+    let mgr = JwtManager::new(test_jwt_config());
     let user = test_user();
     let (access, refresh) = mgr
         .generate_token(
@@ -50,7 +61,7 @@ fn jwt_generate_and_verify() {
 
 #[test]
 fn jwt_refresh_access_token() {
-    let mgr = JwtManager::new(JwtConfig::default());
+    let mgr = JwtManager::new(test_jwt_config());
     let user = test_user();
     let (access, refresh) = mgr.generate_token(&user, vec![], vec![]).unwrap();
 
@@ -67,10 +78,8 @@ fn jwt_refresh_access_token() {
 
 #[test]
 fn jwt_expired_token_fails() {
-    let config = JwtConfig {
-        access_token_ttl_minutes: -5,
-        ..Default::default()
-    };
+    let mut config = test_jwt_config();
+    config.access_token_ttl_minutes = -5;
     let mgr = JwtManager::new(config);
     let user = test_user();
     let (access, _) = mgr.generate_token(&user, vec![], vec![]).unwrap();
@@ -85,7 +94,7 @@ fn jwt_expired_token_fails() {
 
 #[test]
 fn jwt_invalid_token_fails() {
-    let mgr = JwtManager::new(JwtConfig::default());
+    let mgr = JwtManager::new(test_jwt_config());
     let err = mgr.verify_token("not-a-valid-jwt").unwrap_err();
     let msg = err.to_string();
     assert!(

--- a/crates/cogneva/tests/autonomous_executor_test.rs
+++ b/crates/cogneva/tests/autonomous_executor_test.rs
@@ -94,7 +94,12 @@ async fn build_test_state() -> AutonomousTestState {
     let orchestrator = Arc::new(cog_orchestrator::OrchestratorControlImpl::new(dag_executor));
 
     let jwt_manager: Arc<dyn cog_core::AuthProvider> = Arc::new(cog_auth::JwtManager::new(
-        cog_auth::jwt::JwtConfig::default(),
+        cog_auth::jwt::JwtConfig {
+            // `JwtConfig::default()` carries the public placeholder and is
+            // rejected by `JwtManager::new`; tests use a strong fixed secret.
+            secret: "test-hmac-secret-0123456789abcdef0123456789abcdef".into(),
+            ..Default::default()
+        },
     ));
 
     // Build a minimal quota manager backed by in-memory Redis fallback.

--- a/crates/cogneva/tests/e2e_integration.rs
+++ b/crates/cogneva/tests/e2e_integration.rs
@@ -67,8 +67,12 @@ async fn spawn_app_full(
         .await
         .expect("redis conn");
 
-    let jwt_manager: Arc<dyn cog_core::AuthProvider> =
-        Arc::new(JwtManager::new(JwtConfig::default()));
+    let jwt_manager: Arc<dyn cog_core::AuthProvider> = Arc::new(JwtManager::new(JwtConfig {
+        // `JwtConfig::default()` carries the public placeholder and is
+        // rejected by `JwtManager::new`; tests use a strong fixed secret.
+        secret: "test-hmac-secret-0123456789abcdef0123456789abcdef".into(),
+        ..Default::default()
+    }));
     // Generous default so a single request doesn't exhaust quota during E2E.
     let quota_manager = Arc::new(QuotaManager::new(redis_conn, 1_000_000_000));
 


### PR DESCRIPTION
针对 #6（JWT secret 硬编码默认值，生产装配无拒绝机制）：

**现状说明**：上游 main 已包含 83e1702 的装配层加固（COGNEVA_JWT_SECRET 读取 + 占位符拒绝 + 临时随机 secret 回退），但 `JwtManager::new()` 本身仍接受任意 secret——任何绕过装配层直接构造的调用（如 `JwtConfig::default()`）都会静默使用公开占位符 "change-me-in-production"，攻击者可离线伪造 roles=["super_admin"] 的 JWT。

**本次改动（纵深防御，闭环 #6）**：
1. `crates/cog-auth/src/jwt.rs`：`KNOWN_WEAK_SECRET` / `MIN_HMAC_SECRET_LEN` 提升为 pub 常量（单一来源）；`JwtConfig` 新增 `allow_weak_secret`（默认 false，仅限一次性 demo）；`JwtManager::new()` 在 HS256 路径 **fail-fast**：secret 短于 32 字节或等于公开占位符且未显式 opt-in 时 panic 拒绝启动。
2. `crates/cog-auth/src/plugin.rs`：复用 jwt 常量（删除本地重复定义）；`resolve_jwt_config` 对短/占位符 secret 返回友好 Config 错误；demo 模式（`gateway.demo_login_enabled`）置 `allow_weak_secret=true`，装配与构造层语义一致。
3. 测试：受影响测试改用 ≥32 字节强测试 secret；新增 `known_weak_secret_is_rejected` / `short_secret_is_rejected`（should_panic）与 `weak_secret_allowed_when_explicitly_opted_in`。
4. `cogneva.example.json`：gateway 段补注释，说明 JWT 密钥经 `COGNEVA_JWT_SECRET` / 集群 Secret 注入（见 deploy/helm/cogneva/templates/secret.yaml、deploy/scripts/init-secrets.sh），配置文件不存密钥。

**说明**：issue 建议项三"集群场景接 RS256"未包含在本 PR（HS256 + ≥32 字节随机密钥已满足当前装配）；如需可另开 PR。本机无 Rust 工具链，编译/测试验证依赖 CI。

Closes #6